### PR TITLE
[PROD-342]: Exported all java runtime metrics.

### DIFF
--- a/examples/extension/src/main/java/com/example/javaagent/DemoAutoConfigurationCustomizerProvider.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoAutoConfigurationCustomizerProvider.java
@@ -43,8 +43,9 @@ public class DemoAutoConfigurationCustomizerProvider
   private Map<String, String> getDefaultProperties() {
     Map<String, String> properties = new HashMap<>();
     properties.put("otel.exporter.otlp.endpoint", "http://localhost:9319");
-    properties.put("otel.metrics.exporter", "none");
+    properties.put("otel.metrics.exporter", "otlp");
     properties.put("otel.logs.exporter", "otlp");
+    properties.put("otel.instrumentation.runtime-telemetry-java17.enable-all", "true");
     return properties;
   }
 }


### PR DESCRIPTION
# Exported all java runtime metrics.

Set the properties as mentioned below 
- `otel.metrics.exporter` as `otlp`.
- `otel.instrumentation.runtime-telemetry-java17.enable-all` as `true`